### PR TITLE
add @scope/repo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ https://your.verdaccio.url/-/badge/<SCOPE>/<NAME>.svg
 
 e.g
 https://0.0.0.0:4873/-/badge/myorg/my-package.svg
+https://0.0.0.0:4873/-/badge/@myorg/my-package.svg
 https://internal.npm.com/-/badge/my-package.svg
 ```
 

--- a/src/getVersion.js
+++ b/src/getVersion.js
@@ -4,7 +4,7 @@ const getVersion = ({ scope, name, registry } = {}) =>
   new Promise(resolve => {
     const output = {};
     let version = 'undefined';
-    const pkgName = scope ? `@${scope}/${name}` : name;
+    const pkgName = scope ? `@${scope.replace('@', '')}/${name}` : name;
 
     if (!pkgName) {
       output['error'] = `invalid lookup: ${pkgName}`;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -26,6 +26,18 @@ describe('Integration e2e mounted middleware on mock server', () => {
     expect(svgStr).toMatch(/\bv.*<\/text>/);
   });
 
+  it(`returns 200 "vX.X.X" svg for /-/badge/@babel/core.svg`, async () => {
+    const app = mockApp({
+      config: { registry: 'https://registry.npmjs.org', debug: false, format: { label: 'npm@latest' } },
+    });
+    const res = await request(app).get('/-/badge/@babel/core.svg');
+    expect(res.statusCode).toEqual(200);
+    expect(res.headers['content-type']).toEqual('image/svg+xml');
+    const svgStr = res.body.toString();
+    expect(svgStr).toContain('npm@latest</text>');
+    expect(svgStr).toMatch(/\bv.*<\/text>/);
+  });
+
   it(`returns 200 "undefined" svg for /-/badge/a-undefined-random-pkg-name-xyz.svg`, async () => {
     const app = mockApp({
       config: { registry: 'https://registry.npmjs.org', debug: false, format: { label: 'npm@latest' } },


### PR DESCRIPTION
Because `@scope` is better , 

- NPM: `https://www.npmjs.com/package/@babel/core`
- Verdaccio: `/-/web/detail/@fe/test-npm` 
- Shields: `https://img.shields.io/npm/dm/@babel/core.svg`